### PR TITLE
Fix semantic issue for with patron allowlist check #2

### DIFF
--- a/Koha/Plugin/Com/PTFSEurope/Crontab/Controller.pm
+++ b/Koha/Plugin/Com/PTFSEurope/Crontab/Controller.pm
@@ -350,7 +350,9 @@ sub check_user_allowlist {
     if ( my $koha_plugin_crontab_user_allowlist = C4::Context->config('koha_plugin_crontab_user_allowlist') ) {
         my @borrowernumbers = split(',', $koha_plugin_crontab_user_allowlist );
         my $bn = C4::Context->userenv->{number};
-        unless ( grep( /^$bn$/, @borrowernumbers ) ) {
+        if ( grep( /^$bn$/, @borrowernumbers ) ) {
+            return undef;
+        } else {
             return $c->render(
                 status  => 401,
                 openapi => { error => "You are not authorised to use this plugin" }
@@ -358,4 +360,5 @@ sub check_user_allowlist {
         }
     }
 }
+
 1;


### PR DESCRIPTION
I presumed that not explicitly returning in check_user_allowlist for allowed users would not trigger the test in the calling code. I was mistaken and must have made this change without additional testing.