### PR TITLE
feat: support advanced Getopt::Long options and @ARGV positional args in parameter builder

### DIFF
--- a/Koha/Plugin/Com/OpenFifth/Crontab/Cron/Script.pm
+++ b/Koha/Plugin/Com/OpenFifth/Crontab/Cron/Script.pm
@@ -223,88 +223,296 @@ sub parse_script_documentation {
 
 =head2 parse_script_options
 
-Parse command-line options from a Perl script's GetOptions call
+Parse command-line options from a Perl script's GetOptions call and detect
+positional @ARGV usage.
 
-    my $options = $script->parse_script_options('/path/to/script.pl');
+    my $result = $script->parse_script_options('/path/to/script.pl');
 
-Returns arrayref of hashrefs with: name, short_name, type, required
+Returns hashref with:
+  options => arrayref of option hashrefs (name, short_name, type, required,
+             negatable, incremental, repeatable, dest_type)
+  positional_args => arrayref of detected positional argument patterns
+
+For backwards compatibility, when called in list context on code that
+previously expected an arrayref, the options arrayref is returned.
 
 =cut
 
 sub parse_script_options {
     my ( $self, $script_path ) = @_;
 
-    return [] unless -f $script_path;
+    return { options => [], positional_args => [] } unless -f $script_path;
 
-    # Parse GetOptions from the script itself to get option names and types
-    my @options;
-    open my $fh, '<', $script_path or return [];
-    my $in_getoptions    = 0;
+    open my $fh, '<', $script_path or return { options => [], positional_args => [] };
+    my @lines = <$fh>;
+    close $fh;
+
+    my $content = join( '', @lines );
+
+    my @options        = $self->_parse_getoptions_block($content);
+    my @positional_args = $self->_detect_argv_usage( $content, \@lines );
+
+    return {
+        options         => \@options,
+        positional_args => \@positional_args,
+    };
+}
+
+=head2 _parse_getoptions_block
+
+Extract and parse GetOptions specifications from script content.
+Handles both hash-style and list-style GetOptions calls, single and
+double-quoted specs, and the full Getopt::Long spec syntax including
+negatable (!), incremental (+), array (@) and hash (%) destination types.
+
+=cut
+
+sub _parse_getoptions_block {
+    my ( $self, $content ) = @_;
+
+    # Extract GetOptions block(s)
     my $getoptions_block = '';
+    my $in_getoptions    = 0;
 
-    while ( my $line = <$fh> ) {
+    for my $line ( split /\n/, $content ) {
         if ( $line =~ /GetOptions\s*\(/i ) {
             $in_getoptions = 1;
         }
 
         if ($in_getoptions) {
-            $getoptions_block .= $line;
-            if ( $line =~ /\)\s*;/ || $line =~ /\|\|\s*pod2usage/ ) {
+            $getoptions_block .= $line . "\n";
+            if (   $line =~ /\)\s*;/
+                || $line =~ /\)\s*\|\|\s*/
+                || $line =~ /\)\s+or\s+/i )
+            {
                 last;
             }
         }
     }
-    close $fh;
 
-    # Parse option specifications from GetOptions block
-    while ( $getoptions_block =~ /'([^']+)'\s*=>/g ) {
-        my $spec = $1;
-        my ( $name, $short_name, $type, $required ) = ( '', '', 'boolean', 0 );
+    return () unless $getoptions_block;
 
-        # Parse spec format: 'name|alias:type'
-        if ( $spec =~ /^([\w-]+)(?:\|(\w+))?(?:([=:])(\w+))?$/ ) {
-            $name       = $1;
-            $short_name = $2 || '';
-            my $modifier  = $3 || '';
-            my $type_code = $4 || '';
+    # Extract all single or double-quoted strings from the block
+    my @specs;
+    while ( $getoptions_block =~ /(?:'([^']+)'|"([^"]+)")/g ) {
+        push @specs, ( $1 // $2 );
+    }
 
-            # Determine type
-            if ( $modifier eq '=' ) {
-                $required = 1;
-                if ( $type_code eq 's' ) {
-                    $type = 'string';
-                }
-                elsif ( $type_code eq 'i' ) {
-                    $type = 'integer';
-                }
-                elsif ( $type_code eq 'f' ) {
-                    $type = 'float';
-                }
-            }
-            elsif ( $modifier eq ':' ) {
-                $required = 0;
-                if ( $type_code eq 's' ) {
-                    $type = 'string';
-                }
-                elsif ( $type_code eq 'i' ) {
-                    $type = 'integer';
-                }
-                elsif ( $type_code eq 'f' ) {
-                    $type = 'float';
-                }
-            }
+    my @options;
+    for my $spec (@specs) {
+        my $parsed = $self->_parse_option_spec($spec);
+        push @options, $parsed if $parsed;
+    }
 
-            push @options,
-              {
-                name       => $name,
-                short_name => $short_name,
-                type       => $type,
-                required   => $required,
-              };
+    return @options;
+}
+
+=head2 _parse_option_spec
+
+Parse a single Getopt::Long option specification string.
+
+Supported spec format:
+  name[|alias]...[!+][=:][type][repeat]
+
+Where:
+  name|alias  - option names separated by |
+  !           - negatable (allows --no-name)
+  +           - incremental (each use increments value)
+  = or :      - value required (=) or optional (:)
+  type        - s (string), i (integer), o (extended integer), f (float)
+  repeat      - @ (array destination) or % (hash destination)
+
+=cut
+
+sub _parse_option_spec {
+    my ( $self, $spec ) = @_;
+
+    # Full Getopt::Long spec regex
+    # Group 1: name and aliases (e.g. "verbose|v|V" or "help|h|?")
+    # Group 2: negatable (!) or incremental (+)
+    # Group 3: = or : (required/optional value)
+    # Group 4: type code (s, i, o, f) or default number or +
+    # Group 5: destination type (@ or %)
+    return undef
+      unless $spec =~ /^([\w][\w-]*(?:\|[\w?][\w-]*)*)([!+])?(?:([=:])([siof]|\d+|\+))?([%\@])?$/;
+
+    my $names_str = $1;
+    my $modifier  = $2 || '';
+    my $req_char  = $3 || '';
+    my $type_code = $4 || '';
+    my $dest_char = $5 || '';
+
+    # Split names into primary + aliases
+    my @names      = split /\|/, $names_str;
+    my $name       = $names[0];
+    my $short_name = '';
+
+    # Find the first single-character alias as short_name
+    for my $n ( @names[ 1 .. $#names ] ) {
+        if ( length($n) == 1 ) {
+            $short_name = $n;
+            last;
         }
     }
 
-    return \@options;
+    my $type        = 'boolean';
+    my $required    = 0;
+    my $negatable   = 0;
+    my $incremental = 0;
+    my $repeatable  = 0;
+    my $dest_type   = 'scalar';
+
+    # Handle negatable
+    if ( $modifier eq '!' ) {
+        $negatable = 1;
+        $type      = 'boolean';
+    }
+
+    # Handle incremental
+    elsif ( $modifier eq '+' ) {
+        $incremental = 1;
+        $type        = 'incremental';
+    }
+
+    # Handle value types
+    if ($req_char) {
+        $required = ( $req_char eq '=' ) ? 1 : 0;
+
+        if    ( $type_code eq 's' ) { $type = 'string'; }
+        elsif ( $type_code eq 'i' ) { $type = 'integer'; }
+        elsif ( $type_code eq 'o' ) { $type = 'integer'; }
+        elsif ( $type_code eq 'f' ) { $type = 'float'; }
+    }
+
+    # Handle destination type
+    if ( $dest_char eq '@' ) {
+        $dest_type  = 'array';
+        $repeatable = 1;
+    }
+    elsif ( $dest_char eq '%' ) {
+        $dest_type  = 'hash';
+        $repeatable = 1;
+    }
+
+    return {
+        name        => $name,
+        short_name  => $short_name,
+        type        => $type,
+        required    => $required,
+        negatable   => $negatable,
+        incremental => $incremental,
+        repeatable  => $repeatable,
+        dest_type   => $dest_type,
+    };
+}
+
+=head2 _detect_argv_usage
+
+Detect direct @ARGV usage in the script that indicates positional arguments
+not declared in GetOptions.
+
+=cut
+
+sub _detect_argv_usage {
+    my ( $self, $content, $lines ) = @_;
+
+    my @positional_args;
+
+    # Track the highest ARGV index accessed
+    my $max_index = -1;
+    while ( $content =~ /\$ARGV\[(\d+)\]/g ) {
+        my $idx = $1;
+        $max_index = $idx if $idx > $max_index;
+    }
+
+    if ( $max_index >= 0 ) {
+        for my $i ( 0 .. $max_index ) {
+            push @positional_args, {
+                position => $i,
+                source   => "\$ARGV[$i]",
+                label    => _argv_context_label( $content, "\$ARGV[$i]" ),
+            };
+        }
+    }
+
+    # Detect shift @ARGV / shift(@ARGV) patterns
+    my $shift_count = 0;
+    while ( $content =~ /shift\s*[\(]?\s*\@ARGV\s*[\)]?/g ) {
+        $shift_count++;
+    }
+
+    # Only add shift-based positional args if we didn't already find index-based ones
+    if ( $shift_count > 0 && $max_index < 0 ) {
+        for my $i ( 0 .. $shift_count - 1 ) {
+            push @positional_args, {
+                position => $i,
+                source   => 'shift @ARGV',
+                label    => _shift_context_label( $lines, $i ),
+            };
+        }
+    }
+
+    # Detect foreach/for @ARGV loops (variable-length positional args)
+    if ( $content =~ /for(?:each)?\s+(?:my\s+\$\w+\s+)?\(\s*\@ARGV\s*\)/
+        || $content =~ /for(?:each)?\s+(?:my\s+)?\$\w+\s+\(\s*\@ARGV\s*\)/ )
+    {
+        unless (@positional_args) {
+            push @positional_args, {
+                position => 0,
+                source   => '@ARGV loop',
+                label    => 'Positional argument(s)',
+                variadic => 1,
+            };
+        }
+    }
+
+    # Detect bare @ARGV usage in assignments (e.g., my @files = @ARGV)
+    if ( $content =~ /[\@\$]\w+\s*=\s*\@ARGV\b/ && !@positional_args ) {
+        push @positional_args, {
+            position => 0,
+            source   => '@ARGV assignment',
+            label    => 'Positional argument(s)',
+            variadic => 1,
+        };
+    }
+
+    return @positional_args;
+}
+
+sub _argv_context_label {
+    my ( $content, $argv_expr ) = @_;
+
+    # Try to find the variable name assigned from $ARGV[N]
+    my $escaped = quotemeta($argv_expr);
+    if ( $content =~ /(?:my\s+)?\$(\w+)\s*=\s*$escaped/ ) {
+        my $var_name = $1;
+        $var_name =~ s/_/ /g;
+        return ucfirst($var_name);
+    }
+
+    return 'Positional argument';
+}
+
+sub _shift_context_label {
+    my ( $lines, $occurrence_idx ) = @_;
+
+    my $count = 0;
+    for my $line (@$lines) {
+        if ( $line =~ /shift\s*[\(]?\s*\@ARGV\s*[\)]?/ ) {
+            if ( $count == $occurrence_idx ) {
+                # Try to extract variable name from same line
+                if ( $line =~ /(?:my\s+)?\$(\w+)\s*=\s*shift/ ) {
+                    my $var_name = $1;
+                    $var_name =~ s/_/ /g;
+                    return ucfirst($var_name);
+                }
+                last;
+            }
+            $count++;
+        }
+    }
+
+    return 'Positional argument';
 }
 
 =head2 validate_command

--- a/Koha/Plugin/Com/OpenFifth/Crontab/REST/V1/Cron/Scripts.pm
+++ b/Koha/Plugin/Com/OpenFifth/Crontab/REST/V1/Cron/Scripts.pm
@@ -94,18 +94,19 @@ sub get {
         }
 
         # Parse documentation and options
-        my $doc     = $script_model->parse_script_documentation( $script->{path} );
-        my $options = $script_model->parse_script_options( $script->{path} );
+        my $doc    = $script_model->parse_script_documentation( $script->{path} );
+        my $parsed = $script_model->parse_script_options( $script->{path} );
 
         return $c->render(
             status  => 200,
             openapi => {
-                name        => $script->{name},
-                path        => $script->{relative_path},
-                type        => $script->{type},
-                description => $doc->{name_brief} || '',
-                usage_text  => $doc->{usage_text} || '',
-                options     => $options,
+                name            => $script->{name},
+                path            => $script->{relative_path},
+                type            => $script->{type},
+                description     => $doc->{name_brief} || '',
+                usage_text      => $doc->{usage_text} || '',
+                options         => $parsed->{options},
+                positional_args => $parsed->{positional_args},
             }
         );
     }

--- a/Koha/Plugin/Com/OpenFifth/Crontab/api/openapi.json
+++ b/Koha/Plugin/Com/OpenFifth/Crontab/api/openapi.json
@@ -763,7 +763,7 @@
                             },
                             "options": {
                                 "type": "array",
-                                "description": "Parsed command-line options",
+                                "description": "Parsed command-line options from GetOptions",
                                 "items": {
                                     "type": "object",
                                     "properties": {
@@ -773,19 +773,58 @@
                                         },
                                         "short_name": {
                                             "type": "string",
-                                            "description": "Short option alias"
+                                            "description": "Short option alias (single character)"
                                         },
                                         "type": {
                                             "type": "string",
-                                            "description": "Option type (boolean, string, integer)"
-                                        },
-                                        "description": {
-                                            "type": "string",
-                                            "description": "Option description from POD"
+                                            "description": "Option value type",
+                                            "enum": ["boolean", "string", "integer", "float", "incremental"]
                                         },
                                         "required": {
                                             "type": "boolean",
-                                            "description": "Whether option is required"
+                                            "description": "Whether option value is required (= vs : modifier)"
+                                        },
+                                        "negatable": {
+                                            "type": "boolean",
+                                            "description": "Whether the option supports --no-name form"
+                                        },
+                                        "incremental": {
+                                            "type": "boolean",
+                                            "description": "Whether each use increments the value"
+                                        },
+                                        "repeatable": {
+                                            "type": "boolean",
+                                            "description": "Whether the option can be specified multiple times"
+                                        },
+                                        "dest_type": {
+                                            "type": "string",
+                                            "description": "Destination variable type",
+                                            "enum": ["scalar", "array", "hash"]
+                                        }
+                                    }
+                                }
+                            },
+                            "positional_args": {
+                                "type": "array",
+                                "description": "Detected positional arguments from @ARGV usage",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "position": {
+                                            "type": "integer",
+                                            "description": "Argument position (0-based)"
+                                        },
+                                        "source": {
+                                            "type": "string",
+                                            "description": "How the argument is accessed in the script"
+                                        },
+                                        "label": {
+                                            "type": "string",
+                                            "description": "Human-readable label derived from variable name"
+                                        },
+                                        "variadic": {
+                                            "type": "boolean",
+                                            "description": "Whether this accepts a variable number of arguments"
                                         }
                                     }
                                 }

--- a/Koha/Plugin/Com/OpenFifth/Crontab/crontab.tt
+++ b/Koha/Plugin/Com/OpenFifth/Crontab/crontab.tt
@@ -651,8 +651,29 @@
         }
 
         function clearScriptParameters() {
-            // Clear parameter inputs but keep the base script
-            $('#script-options').empty();
+            // Clear all parameter inputs but keep the base script and option structure
+            $('.script-option').each(function() {
+                let $input = $(this);
+                let type = $input.data('option-type');
+                if (type === 'boolean') {
+                    $input.prop('checked', false);
+                } else if (type === 'negatable') {
+                    $input.val('');
+                } else if (type === 'incremental') {
+                    $input.val(0);
+                } else {
+                    $input.val('');
+                }
+            });
+            // Clear repeatable containers back to single empty entry
+            $('.repeatable-container, .repeatable-hash-container').each(function() {
+                let $entries = $(this).children('.repeatable-entry, .hash-entry');
+                $entries.not(':first').remove();
+                $entries.first().find('input').val('');
+            });
+            // Clear positional args
+            $('.positional-arg').val('');
+
             let basePath = $('#base-script-path').val();
             if (basePath) {
                 $('#job-command').val(basePath);
@@ -1081,48 +1102,255 @@
 
             // Build options UI
             let optionsHtml = '';
-            if (scriptData.options && scriptData.options.length > 0) {
+            let hasOptions = scriptData.options && scriptData.options.length > 0;
+            let hasPositional = scriptData.positional_args && scriptData.positional_args.length > 0;
+
+            if (hasOptions) {
                 scriptData.options.forEach(function(option) {
                     let optionId = 'opt-' + option.name.replace(/[^a-zA-Z0-9]/g, '-');
                     let shortName = option.short_name ? ' (-' + option.short_name + ')' : '';
 
-                    if (option.type === 'boolean') {
-                        // Checkbox for boolean options
+                    if (option.type === 'boolean' && !option.negatable) {
+                        // Simple checkbox for boolean options
                         optionsHtml += `
                             <div class="form-check mb-2">
                                 <input class="form-check-input script-option" type="checkbox"
                                        id="${optionId}"
                                        data-option-name="${option.name}"
-                                       data-option-type="${option.type}">
+                                       data-option-type="boolean">
                                 <label class="form-check-label" for="${optionId}">
                                     <code>--${option.name}${shortName}</code>
                                 </label>
                             </div>
                         `;
+                    } else if (option.negatable) {
+                        // Negatable boolean: three-state select (unset / --name / --no-name)
+                        optionsHtml += `
+                            <div class="mb-3">
+                                <label for="${optionId}" class="form-label">
+                                    <code>--${option.name}${shortName}</code>
+                                    <small class="text-muted">(negatable)</small>
+                                </label>
+                                <select class="form-control form-control-sm script-option"
+                                        id="${optionId}"
+                                        data-option-name="${option.name}"
+                                        data-option-type="negatable">
+                                    <option value="">-- not set --</option>
+                                    <option value="yes">--${option.name}</option>
+                                    <option value="no">--no-${option.name}</option>
+                                </select>
+                            </div>
+                        `;
+                    } else if (option.type === 'incremental') {
+                        // Incremental: number input (how many times to repeat the flag)
+                        optionsHtml += `
+                            <div class="mb-3">
+                                <label for="${optionId}" class="form-label">
+                                    <code>--${option.name}${shortName}</code>
+                                    <small class="text-muted">(repeatable flag)</small>
+                                </label>
+                                <input type="number" min="0" max="10"
+                                       class="form-control form-control-sm script-option"
+                                       id="${optionId}"
+                                       data-option-name="${option.name}"
+                                       data-option-type="incremental"
+                                       value="0"
+                                       placeholder="Number of times to include">
+                            </div>
+                        `;
+                    } else if (option.repeatable && option.dest_type === 'hash') {
+                        // Hash destination: key=value pair inputs
+                        optionsHtml += `
+                            <div class="mb-3">
+                                <label class="form-label">
+                                    <code>--${option.name}${shortName}</code>
+                                    ${option.required ? '<span class="text-danger">*</span>' : ''}
+                                    <small class="text-muted">(key=value pairs)</small>
+                                </label>
+                                <div class="repeatable-hash-container" id="${optionId}-container"
+                                     data-option-name="${option.name}"
+                                     data-option-type="${option.type}"
+                                     data-dest-type="hash">
+                                    <div class="input-group input-group-sm mb-1 hash-entry">
+                                        <input type="text" class="form-control hash-key" placeholder="key">
+                                        <span class="input-group-text">=</span>
+                                        <input type="text" class="form-control hash-value" placeholder="value">
+                                        <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                                            <i class="fa fa-times"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <button type="button" class="btn btn-outline-secondary btn-sm add-hash-entry"
+                                        data-target="${optionId}-container">
+                                    <i class="fa fa-plus"></i> Add pair
+                                </button>
+                            </div>
+                        `;
+                    } else if (option.repeatable) {
+                        // Array destination: multiple value inputs
+                        optionsHtml += `
+                            <div class="mb-3">
+                                <label class="form-label">
+                                    <code>--${option.name}${shortName}</code>
+                                    ${option.required ? '<span class="text-danger">*</span>' : ''}
+                                    <small class="text-muted">(repeatable)</small>
+                                </label>
+                                <div class="repeatable-container" id="${optionId}-container"
+                                     data-option-name="${option.name}"
+                                     data-option-type="${option.type}"
+                                     data-dest-type="array">
+                                    <div class="input-group input-group-sm mb-1 repeatable-entry">
+                                        <input type="${option.type === 'integer' ? 'number' : 'text'}"
+                                               class="form-control repeatable-value"
+                                               placeholder="${option.type === 'string' ? 'Enter value' : 'Enter number'}">
+                                        <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                                            <i class="fa fa-times"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <button type="button" class="btn btn-outline-secondary btn-sm add-repeatable-entry"
+                                        data-target="${optionId}-container"
+                                        data-input-type="${option.type === 'integer' ? 'number' : 'text'}"
+                                        data-placeholder="${option.type === 'string' ? 'Enter value' : 'Enter number'}">
+                                    <i class="fa fa-plus"></i> Add value
+                                </button>
+                            </div>
+                        `;
                     } else {
-                        // Text input for string/integer options
+                        // Simple text/number input for scalar string/integer/float options
                         optionsHtml += `
                             <div class="mb-3">
                                 <label for="${optionId}" class="form-label">
                                     <code>--${option.name}${shortName}</code>
                                     ${option.required ? '<span class="text-danger">*</span>' : ''}
                                 </label>
-                                <input type="${option.type === 'integer' ? 'number' : 'text'}"
+                                <input type="${option.type === 'integer' || option.type === 'float' ? 'number' : 'text'}"
                                        class="form-control form-control-sm script-option"
                                        id="${optionId}"
                                        data-option-name="${option.name}"
                                        data-option-type="${option.type}"
+                                       ${option.type === 'float' ? 'step="any"' : ''}
                                        placeholder="${option.type === 'string' ? 'Enter value' : 'Enter number'}">
                             </div>
                         `;
                     }
                 });
-            } else {
-                optionsHtml = '<p class="text-muted">No documented options for this script.</p>';
+            }
+
+            // Positional arguments section
+            if (hasPositional) {
+                optionsHtml += '<hr><h6 class="text-muted"><i class="fa fa-list-ol"></i> Positional Arguments</h6>';
+                optionsHtml += '<p class="text-muted small">These arguments are passed directly (without --flags) and are position-dependent.</p>';
+
+                scriptData.positional_args.forEach(function(arg) {
+                    let argId = 'pos-arg-' + arg.position;
+
+                    if (arg.variadic) {
+                        // Variable-length positional args
+                        optionsHtml += `
+                            <div class="mb-3">
+                                <label class="form-label">
+                                    <code>${arg.label}</code>
+                                    <small class="text-muted">(one or more values)</small>
+                                </label>
+                                <div class="repeatable-container positional-variadic" id="${argId}-container"
+                                     data-position="${arg.position}" data-variadic="true">
+                                    <div class="input-group input-group-sm mb-1 repeatable-entry">
+                                        <input type="text" class="form-control repeatable-value positional-arg"
+                                               placeholder="Enter value"
+                                               data-position="${arg.position}">
+                                        <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                                            <i class="fa fa-times"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <button type="button" class="btn btn-outline-secondary btn-sm add-repeatable-entry"
+                                        data-target="${argId}-container"
+                                        data-input-type="text"
+                                        data-placeholder="Enter value">
+                                    <i class="fa fa-plus"></i> Add value
+                                </button>
+                            </div>
+                        `;
+                    } else {
+                        optionsHtml += `
+                            <div class="mb-3">
+                                <label for="${argId}" class="form-label">
+                                    <code>${arg.label}</code>
+                                    <small class="text-muted">(position ${arg.position + 1})</small>
+                                </label>
+                                <input type="text"
+                                       class="form-control form-control-sm positional-arg"
+                                       id="${argId}"
+                                       data-position="${arg.position}"
+                                       placeholder="Enter value">
+                            </div>
+                        `;
+                    }
+                });
+            }
+
+            if (!hasOptions && !hasPositional) {
+                optionsHtml = '<p class="text-muted">No documented options or arguments detected for this script.</p>';
             }
 
             $('#script-options').html(optionsHtml);
             $('#script-params-container').show();
+
+            // Bind repeatable entry handlers
+            bindRepeatableHandlers();
+        }
+
+        function bindRepeatableHandlers() {
+            // Add repeatable value entry
+            $('.add-repeatable-entry').off('click').on('click', function() {
+                let targetId = $(this).data('target');
+                let inputType = $(this).data('input-type') || 'text';
+                let placeholder = $(this).data('placeholder') || 'Enter value';
+                let entryHtml = `
+                    <div class="input-group input-group-sm mb-1 repeatable-entry">
+                        <input type="${inputType}" class="form-control repeatable-value"
+                               placeholder="${placeholder}">
+                        <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                            <i class="fa fa-times"></i>
+                        </button>
+                    </div>
+                `;
+                $('#' + targetId).append(entryHtml);
+                bindRemoveHandlers();
+            });
+
+            // Add hash entry
+            $('.add-hash-entry').off('click').on('click', function() {
+                let targetId = $(this).data('target');
+                let entryHtml = `
+                    <div class="input-group input-group-sm mb-1 hash-entry">
+                        <input type="text" class="form-control hash-key" placeholder="key">
+                        <span class="input-group-text">=</span>
+                        <input type="text" class="form-control hash-value" placeholder="value">
+                        <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                            <i class="fa fa-times"></i>
+                        </button>
+                    </div>
+                `;
+                $('#' + targetId).append(entryHtml);
+                bindRemoveHandlers();
+            });
+
+            bindRemoveHandlers();
+        }
+
+        function bindRemoveHandlers() {
+            $('.remove-repeatable-entry').off('click').on('click', function() {
+                let $container = $(this).closest('.repeatable-container, .repeatable-hash-container');
+                // Keep at least one entry
+                if ($container.children('.repeatable-entry, .hash-entry').length > 1) {
+                    $(this).closest('.repeatable-entry, .hash-entry').remove();
+                } else {
+                    // Clear the inputs instead of removing the last entry
+                    $(this).closest('.repeatable-entry, .hash-entry').find('input').val('');
+                }
+            });
         }
 
         function showPodViewer() {
@@ -1152,6 +1380,8 @@
             }
 
             let params = [];
+
+            // Process simple scalar options (boolean, string, integer, float, negatable, incremental)
             $('.script-option').each(function() {
                 let $input = $(this);
                 let optionName = $input.data('option-name');
@@ -1159,6 +1389,18 @@
 
                 if (optionType === 'boolean') {
                     if ($input.is(':checked')) {
+                        params.push('--' + optionName);
+                    }
+                } else if (optionType === 'negatable') {
+                    let val = $input.val();
+                    if (val === 'yes') {
+                        params.push('--' + optionName);
+                    } else if (val === 'no') {
+                        params.push('--no-' + optionName);
+                    }
+                } else if (optionType === 'incremental') {
+                    let count = parseInt($input.val()) || 0;
+                    for (let i = 0; i < count; i++) {
                         params.push('--' + optionName);
                     }
                 } else {
@@ -1169,9 +1411,62 @@
                 }
             });
 
+            // Process repeatable array options
+            $('.repeatable-container[data-dest-type="array"]').each(function() {
+                let optionName = $(this).data('option-name');
+                $(this).find('.repeatable-value').each(function() {
+                    let value = $(this).val();
+                    if (value && value.trim() !== '') {
+                        params.push('--' + optionName + '=' + value.trim());
+                    }
+                });
+            });
+
+            // Process repeatable hash options
+            $('.repeatable-hash-container[data-dest-type="hash"]').each(function() {
+                let optionName = $(this).data('option-name');
+                $(this).find('.hash-entry').each(function() {
+                    let key = $(this).find('.hash-key').val();
+                    let value = $(this).find('.hash-value').val();
+                    if (key && key.trim() !== '') {
+                        let pair = key.trim() + '=' + (value ? value.trim() : '');
+                        params.push('--' + optionName + '=' + pair);
+                    }
+                });
+            });
+
             let fullCommand = basePath;
             if (params.length > 0) {
                 fullCommand += ' ' + params.join(' ');
+            }
+
+            // Process positional arguments (appended after flags)
+            let positionalValues = [];
+            // Fixed positional args (ordered by position)
+            let fixedArgs = [];
+            $('.positional-arg').not('.repeatable-container .positional-arg').each(function() {
+                let position = parseInt($(this).data('position'));
+                let value = $(this).val();
+                if (value && value.trim() !== '') {
+                    fixedArgs[position] = value.trim();
+                }
+            });
+            // Fill in fixed args in order
+            for (let i = 0; i < fixedArgs.length; i++) {
+                if (fixedArgs[i]) {
+                    positionalValues.push(fixedArgs[i]);
+                }
+            }
+            // Variadic positional args
+            $('.positional-variadic .repeatable-value').each(function() {
+                let value = $(this).val();
+                if (value && value.trim() !== '') {
+                    positionalValues.push(value.trim());
+                }
+            });
+
+            if (positionalValues.length > 0) {
+                fullCommand += ' ' + positionalValues.join(' ');
             }
 
             $('#job-command').val(fullCommand);
@@ -1202,8 +1497,8 @@
 
         function parseCommandParameters(command) {
             // Extract parameters from command
-            // Expected format: script_path --option=value --flag --other=val
-            let params = {};
+            // Returns: { flags: {name: value|true|[values]}, positional: [values] }
+            let result = { flags: {}, positional: [] };
 
             // Split command by spaces, but preserve values with spaces in quotes
             let parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
@@ -1212,11 +1507,11 @@
             for (let i = 1; i < parts.length; i++) {
                 let part = parts[i];
 
-                // Handle --option=value format
+                // Handle --option=value or --option format (including --no-option)
                 if (part.startsWith('--')) {
                     let match = part.match(/^--([^=]+)(?:=(.*))?$/);
                     if (match) {
-                        let name = match[1];
+                        let name = match[1]; // Raw name including "no-" prefix if present
                         let value = match[2] !== undefined ? match[2] : true;
 
                         // Remove quotes if present
@@ -1224,34 +1519,193 @@
                             value = value.replace(/^["']|["']$/g, '');
                         }
 
-                        params[name] = value;
+                        if (result.flags.hasOwnProperty(name)) {
+                            // Repeated option: collect into array
+                            let existing = result.flags[name];
+                            if (Array.isArray(existing)) {
+                                existing.push(value);
+                            } else {
+                                result.flags[name] = [existing, value];
+                            }
+                        } else {
+                            result.flags[name] = value;
+                        }
                     }
                 }
                 // Handle -x format (short options)
                 else if (part.startsWith('-') && !part.startsWith('--')) {
-                    // For now, skip short options as we'll map them via the builder
-                    // Could enhance this to map short to long names
+                    // Map short options to long names if possible
+                    if (currentScriptData && currentScriptData.options) {
+                        let shortFlag = part.substring(1);
+                        let matched = currentScriptData.options.find(o => o.short_name === shortFlag);
+                        if (matched) {
+                            result.flags[matched.name] = true;
+                        }
+                    }
+                }
+                // Positional argument (no leading -)
+                else {
+                    let value = part.replace(/^["']|["']$/g, '');
+                    result.positional.push(value);
                 }
             }
 
-            return params;
+            return result;
         }
 
-        function populateScriptParameters(params) {
-            // Populate each parameter input with its value
+        function populateScriptParameters(parsed) {
+            let params = parsed.flags || parsed;
+            let positional = parsed.positional || [];
+
+            // Populate scalar options
             $('.script-option').each(function() {
                 let $input = $(this);
                 let optionName = $input.data('option-name');
                 let optionType = $input.data('option-type');
 
-                if (params.hasOwnProperty(optionName)) {
+                if (optionType === 'negatable') {
+                    // For negatable options, check both --name and --no-name
+                    if (params.hasOwnProperty(optionName)) {
+                        $input.val('yes');
+                    } else if (params.hasOwnProperty('no-' + optionName)) {
+                        $input.val('no');
+                    }
+                } else if (params.hasOwnProperty(optionName)) {
+                    let value = params[optionName];
+
                     if (optionType === 'boolean') {
-                        $input.prop('checked', !!params[optionName]);
+                        $input.prop('checked', !!value);
+                    } else if (optionType === 'incremental') {
+                        // Count how many times the flag appears
+                        if (Array.isArray(value)) {
+                            $input.val(value.length);
+                        } else if (value === true) {
+                            $input.val(1);
+                        }
                     } else {
-                        $input.val(params[optionName]);
+                        // Simple scalar value
+                        if (!Array.isArray(value)) {
+                            $input.val(value);
+                        }
                     }
                 }
             });
+
+            // Populate repeatable array options
+            $('.repeatable-container[data-dest-type="array"]').each(function() {
+                let $container = $(this);
+                let optionName = $container.data('option-name');
+
+                if (params.hasOwnProperty(optionName)) {
+                    let values = params[optionName];
+                    if (!Array.isArray(values)) {
+                        values = [values];
+                    }
+
+                    // Set first value in existing entry
+                    let $entries = $container.find('.repeatable-entry');
+                    values.forEach(function(val, idx) {
+                        if (idx === 0) {
+                            $entries.first().find('.repeatable-value').val(val === true ? '' : val);
+                        } else {
+                            // Add new entries for additional values
+                            let entryHtml = `
+                                <div class="input-group input-group-sm mb-1 repeatable-entry">
+                                    <input type="text" class="form-control repeatable-value"
+                                           value="${escapeHtml(String(val === true ? '' : val))}"
+                                           placeholder="Enter value">
+                                    <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                                        <i class="fa fa-times"></i>
+                                    </button>
+                                </div>
+                            `;
+                            $container.append(entryHtml);
+                        }
+                    });
+                }
+            });
+
+            // Populate repeatable hash options
+            $('.repeatable-hash-container[data-dest-type="hash"]').each(function() {
+                let $container = $(this);
+                let optionName = $container.data('option-name');
+
+                if (params.hasOwnProperty(optionName)) {
+                    let values = params[optionName];
+                    if (!Array.isArray(values)) {
+                        values = [values];
+                    }
+
+                    let $entries = $container.find('.hash-entry');
+                    values.forEach(function(val, idx) {
+                        if (typeof val === 'string' && val.indexOf('=') !== -1) {
+                            let kv = val.split('=');
+                            let key = kv[0];
+                            let value = kv.slice(1).join('=');
+
+                            if (idx === 0) {
+                                $entries.first().find('.hash-key').val(key);
+                                $entries.first().find('.hash-value').val(value);
+                            } else {
+                                let entryHtml = `
+                                    <div class="input-group input-group-sm mb-1 hash-entry">
+                                        <input type="text" class="form-control hash-key" placeholder="key" value="${escapeHtml(key)}">
+                                        <span class="input-group-text">=</span>
+                                        <input type="text" class="form-control hash-value" placeholder="value" value="${escapeHtml(value)}">
+                                        <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                                            <i class="fa fa-times"></i>
+                                        </button>
+                                    </div>
+                                `;
+                                $container.append(entryHtml);
+                            }
+                        }
+                    });
+                }
+            });
+
+            // Populate positional arguments
+            if (positional.length > 0) {
+                let $fixedArgs = $('.positional-arg').not('.repeatable-container .positional-arg');
+                $fixedArgs.each(function() {
+                    let pos = parseInt($(this).data('position'));
+                    if (pos < positional.length) {
+                        $(this).val(positional[pos]);
+                    }
+                });
+
+                // Handle variadic args (remaining positional values after fixed positions)
+                let fixedCount = $fixedArgs.length;
+                let remainingPositional = positional.slice(fixedCount);
+                if (remainingPositional.length > 0) {
+                    let $variadic = $('.positional-variadic');
+                    if ($variadic.length > 0) {
+                        $variadic.each(function() {
+                            let $container = $(this);
+                            remainingPositional.forEach(function(val, idx) {
+                                if (idx === 0) {
+                                    $container.find('.repeatable-value').first().val(val);
+                                } else {
+                                    let entryHtml = `
+                                        <div class="input-group input-group-sm mb-1 repeatable-entry">
+                                            <input type="text" class="form-control repeatable-value positional-arg"
+                                                   value="${escapeHtml(val)}"
+                                                   placeholder="Enter value">
+                                            <button type="button" class="btn btn-outline-danger btn-sm remove-repeatable-entry">
+                                                <i class="fa fa-times"></i>
+                                            </button>
+                                        </div>
+                                    `;
+                                    $container.append(entryHtml);
+                                }
+                            });
+                        });
+                    }
+                }
+            }
+
+            // Re-bind handlers for dynamically added elements
+            bindRepeatableHandlers();
         }
     </script>
 [% END %]


### PR DESCRIPTION
The script parameter parser now handles the full Getopt::Long spec syntax:
- Negatable options (!) with --no-name support
- Incremental options (+) with repeat count
- Array destination (@) with repeatable value inputs
- Hash destination (%) with key=value pair inputs
- Multiple aliases (name|a|b) and ? alias
- Double-quoted specs and list-style GetOptions calls
- Extended integer (o) and float (f) types

Additionally, scripts that use @ARGV directly (without GetOptions) are now
detected via $ARGV[N] index access, shift @ARGV, for/foreach @ARGV loops,
and @ARGV assignments. These appear as positional argument fields in the
command builder UI.

The frontend command builder, parser, and populator are updated to handle
all new option types including round-trip editing of existing commands.

https://claude.ai/code/session_016s3Vxd2VnNp2EFCn1C3NvJ